### PR TITLE
fix: change type of const.fuels from set to list

### DIFF
--- a/switchwrapper/const.py
+++ b/switchwrapper/const.py
@@ -3,7 +3,7 @@ financial_parameters = {
     "interest_rate": 0.029,
 }
 
-fuels = {"Coal", "NaturalGas", "Uranium"}
+fuels = ["Coal", "NaturalGas", "Uranium"]
 
 load_parameters = {
     "existing_local_td": 99999,


### PR DESCRIPTION
Fix issue raised in https://github.com/Breakthrough-Energy/SwitchWrapper/pull/27#issuecomment-833816574, introduced by accident within #22.

Tested manually, it fixes the problem.