### PR TITLE
fix: pass required bus parameter to build_load_zones

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -36,7 +36,7 @@ def grid_to_switch(grid, outputfolder):
     )
 
     load_zones_filepath = os.path.join(outputfolder, "load_zones.csv")
-    build_load_zones().to_csv(load_zones_filepath, index=False)
+    build_load_zones(grid.bus).to_csv(load_zones_filepath, index=False)
 
     non_fuel_energy_source_filepath = os.path.join(
         outputfolder, "non_fuel_energy_source.csv"


### PR DESCRIPTION
### Purpose

Fix a bug introduced in https://github.com/Breakthrough-Energy/SwitchWrapper/pull/20.

### What is the code doing

Ensuring that we pass the required `bus` parameter to the `build_load_zones` function.

### Testing

Tested manually using the newly-created `mvp_empty_dataframe` branch, which ensures that all placeholder functions return an empty data frame so that we are never stopped early by any `to_csv` calls on a `NoneType` object.

Before:
```python
>>> from switchwrapper.grid_to_switch import grid_to_switch
>>> from powersimdata import Grid
>>> grid = Grid("Western")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> grid_to_switch(grid, "output")
Please enter base study year (normally PowerSimData scenario year): 2030
Please enter the number of investment stages: 3
Multi stage expansion identified.
Please enter investment period year, separate by space: 2020 2025 2030
Please enter start year for each period, separate by space: 2020 2025 2030
Please enter end year for each period, separate by space: 2024 2029 2034
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\SwitchWrapper\switchwrapper\grid_to_switch.py", line 39, in grid_to_switch
    build_load_zones().to_csv(load_zones_filepath, index=False)
TypeError: build_load_zones() missing 1 required positional argument: 'bus'
```
After:
```python
>>> from switchwrapper.grid_to_switch import grid_to_switch
>>> from powersimdata import Grid
>>> grid = Grid("Western")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> grid_to_switch(grid, "output")
Please enter base study year (normally PowerSimData scenario year): 2030
Please enter the number of investment stages: 3
Multi stage expansion identified.
Please enter investment period year, separate by space: 2020 2025 2030
Please enter start year for each period, separate by space: 2020 2025 2030
Please enter end year for each period, separate by space: 2024 2029 2034
>>>
```

### Time to review

2 minutes.