### PR TITLE
fix: run os.makedirs on outputfolder for robustness

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -6,6 +6,9 @@ from switchwrapper import const
 
 
 def grid_to_switch(grid, outputfolder):
+    # Create the outputfolder, if it doesn't already exist
+    os.makedirs(outputfolder, exist_ok=True)
+
     # First, prompt the user for information not contained in const or the passed grid
     base_year = get_base_year()
     inv_period, period_start, period_end = get_inv_periods()


### PR DESCRIPTION
### Purpose

Allow the user to pass an `outputfolder` that does not yet exist on their local machine; if so, create it automatically.