### PR TITLE
fix: cleanup of gen_build_costs logic

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -195,7 +195,7 @@ def build_gen_build_costs(plant, cost_at_min_power, inv_period):
     """
     # Build lists for each columns, which apply to one year
     original_plant_indices = [f"g{p}" for p in plant.index.tolist()]
-    overnight_costs = plant["type"].map(const.investment_costs_by_type)
+    overnight_costs = plant["type"].map(const.investment_costs_by_type).tolist()
     gen_fixed_om = (cost_at_min_power / plant.Pmax).fillna(0.0).tolist()
 
     # Extend these lists to multiple years


### PR DESCRIPTION
### Purpose

Clean up bugs introduced with #26.

### What is the code doing

- We pass the plant data frame, instead of the Grid, to `build_gen_build_costs`.
- We correct bugs in the syntax/logic of the lambda function within `linearize_gencost`.
- We coerce `overnight_costs` from a pandas Series to a list, so that we can properly append multiple copies together.

### Testing

Using the `mvp_empty_dataframe` branch for testing (to avoid AttributeErrors for NoneType placeholders for data frames). Before:
```python
>>> from powersimdata import Grid
>>> from switchwrapper.grid_to_switch import grid_to_switch
>>> grid = Grid("Western")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> grid_to_switch(grid, "output")
Please enter base study year (normally PowerSimData scenario year): 2030
Please enter the number of investment stages: 1
Single stage expansion identified.
Please enter investment period year, separate by space: 2030
Please enter start year for each period, separate by space: 2030
Please enter end year for each period, separate by space: 2030
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\DanielOlsen\repos\bes\SwitchWrapper\switchwrapper\grid_to_switch.py", line 17, in grid_to_switch
    cost_at_min_power, single_segment_slope = linearize_gencost(grid)
  File "C:\Users\DanielOlsen\repos\bes\SwitchWrapper\switchwrapper\grid_to_switch.py", line 137, in linearize_gencost
    plant_mod.Pmin = plant_mod.apply(
  File "C:\Python38\lib\site-packages\pandas\core\frame.py", line 7768, in apply
    return op.get_result()
  File "C:\Python38\lib\site-packages\pandas\core\apply.py", line 185, in get_result
    return self.apply_standard()
  File "C:\Python38\lib\site-packages\pandas\core\apply.py", line 276, in apply_standard
    results, res_index = self.apply_series_generator()
  File "C:\Python38\lib\site-packages\pandas\core\apply.py", line 290, in apply_series_generator
    results[i] = self.f(v)
  File "C:\Users\DanielOlsen\repos\bes\SwitchWrapper\switchwrapper\grid_to_switch.py", line 139, in <lambda>
    if const.assumed_pmin[x.type] != None else x.Pmin
AttributeError: module 'switchwrapper.const' has no attribute 'assumed_pmin'
```
After:
```python
>>> from powersimdata import Grid
>>> from switchwrapper.grid_to_switch import grid_to_switch
>>> grid = Grid("Western")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
>>> grid_to_switch(grid, "output")
Please enter base study year (normally PowerSimData scenario year): 2030
Please enter the number of investment stages: 1
Single stage expansion identified.
Please enter investment period year, separate by space: 2030
Please enter start year for each period, separate by space: 2030
Please enter end year for each period, separate by space: 2030
>>>
```

### Time to review
5 minutes.