### PR TITLE
chore: add bug_report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: Bug report
+labels: bug
+assignees: ahurli, BainanXia, danielolsen, jon-hagg, rouille
+
+---
+
+# :beetle:
+
+- [ ] I have checked that this issue has not already been reported.
+
+
+### Bug summary
+A short 1-2 sentences that succinctly describes the bug.
+
+### Code for reproduction
+A minimum code snippet required to reproduce the bug. Please make sure to minimize the
+number of dependencies required.
+```python
+# Paste your code here
+#
+#
+```
+
+### Actual outcome
+The output produced by the above code, which may be a screenshot, console output, etc.
+```shell
+# If applicable, paste the console output here
+#
+#
+```
+
+### Expected outcome
+A description of the expected outcome from the code snippet.
+
+### Environment
+Please specify your platform and versions of the relevant libraries you are using:
+* Operating system:
+* SwitchWrapper revision (run `git rev-parse origin/HEAD`):
+* Python version:
+* Jupyter version (if applicable):
+* Other libraries:
+
+### Additional context
+Add any other context about the problem here.


### PR DESCRIPTION
### Purpose

Add bug report issue template. Copied from PowerSimData, the only change I made was substituting `SwitchWrapper revision` in place of `PowerSimData revision`

### What is the code doing.

N/A.

### Time to review

1 minute.