### PR TITLE
chore: add entries to fuel_mapping to cover 'dfo' and 'other' types

### DIFF
--- a/switchwrapper/const.py
+++ b/switchwrapper/const.py
@@ -3,7 +3,7 @@ financial_parameters = {
     "interest_rate": 0.029,
 }
 
-fuels = ["Coal", "NaturalGas", "Uranium"]
+fuels = ["Coal", "NaturalGas", "Uranium", "Petroleum", "Other"]
 
 fuel_mapping = {
     "wind": "Wind",
@@ -14,6 +14,8 @@ fuel_mapping = {
     "coal": "Coal",
     "ng": "NaturalGas",
     "nuclear": "Uranium",
+    "dfo": "Petroleum",
+    "other": "Other",
 }
 
 load_parameters = {


### PR DESCRIPTION
### Purpose

Update `fuel_mapping` to include entries for `"dfo"` and `"other"` plant types. Closes #38.

### Testing

```python
>>> from powersimdata import Grid
>>> from switchwrapper.grid_to_switch import grid_to_switch
>>> grid_to_switch(Grid("Eastern"), "output_eastern")
Reading bus.csv
Reading plant.csv
Reading gencost.csv
Reading branch.csv
Reading dcline.csv
Reading sub.csv
Reading bus2sub.csv
Reading zone.csv
Please enter base study year (normally PowerSimData scenario year): 2030
Please enter the number of investment stages: 1
Single stage expansion identified.
Please enter investment period year, separate by space: 2030
Please enter start year for each period, separate by space: 2030
Please enter end year for each period, separate by space: 2030
>>>
```

### Time to review

2 minutes.