### PR TITLE
feat: add skeleton for applying temporal mapping to inputs

### DIFF
--- a/switchwrapper/profiles_to_switch.py
+++ b/switchwrapper/profiles_to_switch.py
@@ -3,7 +3,14 @@ import os
 import pandas as pd
 
 
-def profiles_to_switch(grid, profiles, timepoints, timeseries, mapping, output_folder):
+def profiles_to_switch(
+    grid,
+    profiles,
+    timepoints,
+    timeseries_to_duration,
+    timestamp_to_timepoints,
+    output_folder,
+):
     """Using the provided mapping of hourly timestamps to timepoints, plus hourly
     profiles, create and save CSVs which produce temporal data needed for Switch.
     Inputs are indexed by 'timestamps', while outputs are 'timeseries', each of which
@@ -15,47 +22,54 @@ def profiles_to_switch(grid, profiles, timepoints, timeseries, mapping, output_f
         representing plant IDs (for hydro, solar, and wind) or zone IDs (for demand).
     :param pandas.DataFrame timepoints: data frame, indexed by timepoint_id, with
         columns 'timestamp' and 'timeseries'.
-    :param pandas.Series timeseries: durations (values) of each timeseries (index).
-    :param pandas.Series mapping: timepoints (values) of each timestamp (index).
+    :param pandas.Series timeseries_to_duration: durations (values) of each timeseries
+        (index).
+    :param pandas.Series timestamp_to_timepoints: timepoints (values) of each timestamp
+        (index).
     :param str output_folder: the location to save outputs, created as necessary.
     """
     # Create the output folder, if it doesn't already exist
     os.makedirs(output_folder, exist_ok=True)
 
     loads_filepath = os.path.join(output_folder, "loads.csv")
-    loads = build_loads(grid.bus, profiles["demand"], mapping)
+    loads = build_loads(grid.bus, profiles["demand"], timestamp_to_timepoints)
     loads.to_csv(loads_filepath, index=False)
 
     timeseries_filepath = os.path.join(output_folder, "timeseries.csv")
-    timeseries = build_timeseries(timeseries, mapping, timepoints)
+    timeseries = build_timeseries(
+        timeseries_to_duration, timestamp_to_timepoints, timepoints
+    )
     timeseries.to_csv(timeseries_filepath, index=False)
 
     variable_capacity_factors_filepath = os.path.join(
         output_folder, "variable_capacity_factors.csv"
     )
     variable_capacity_factors = build_variable_capacity_factors(
-        profiles, grid.plant, mapping
+        profiles, grid.plant, timestamp_to_timepoints
     )
     variable_capacity_factors.to_csv(variable_capacity_factors_filepath, index=False)
 
 
-def build_loads(bus, demand, mapping):
+def build_loads(bus, demand, timestamp_to_timepoints):
     """Map timestamps to timepoints for demand data frame.
 
     :param pandas.DataFrame bus: bus data from a Grid object.
     :param pandas.DataFrame demand: demand by timestamp (index) and zone IDs (columns).
-    :param pandas.Series mapping: timepoints (values) of each timestamp (index).
+    :param pandas.Series timestamp_to_timepoints: timepoints (values) of each timestamp
+        (index).
     :return: (*pandas.DataFrame*) -- data frame of demand at each bus/timepoint.
     """
     return pd.DataFrame()
 
 
-def build_timeseries(timeseries, mapping, timepoints):
-    """Add extra information to ``timeseries``, based on the information in ``mapping``
-    and ``timepoints``.
+def build_timeseries(timeseries_to_duration, timestamp_to_timepoints, timepoints):
+    """Add extra information to ``timeseries_to_duration``, based on the information in
+    ``timestamp_to_timepoints`` and ``timepoints``.
 
-    :param pandas.Series timeseries: durations (values) of each timeseries (index).
-    :param pandas.Series mapping: timepoints (values) of each timestamp (index).
+    :param pandas.Series timeseries_to_duration: durations (values) of each timeseries
+        (index).
+    :param pandas.Series timestamp_to_timepoints: timepoints (values) of each timestamp
+        (index).
     :param pandas.DataFrame timepoints: data frame, indexed by timepoint_id, with
         columns 'timestamp' and 'timeseries'.
     :return: (*pandas.DataFrame*) -- data frame containing all timeseries information.
@@ -63,14 +77,15 @@ def build_timeseries(timeseries, mapping, timepoints):
     return pd.DataFrame()
 
 
-def build_variable_capacity_factors(profiles, plant, mapping):
+def build_variable_capacity_factors(profiles, plant, timestamp_to_timepoints):
     """Map timestamps to timepoints for variable generation data frames.
 
     :param dict profiles: keys include {"hydro", "solar", "wind"}, values are the
         corresponding pandas data frames, indexed by hourly timestamp, with columns
         representing plant IDs.
     :param pandas.DataFrame plant: plant data from a Grid object.
-    :param pandas.Series mapping: timepoints (values) of each timestamp (index).
+    :param pandas.Series timestamp_to_timepoints: timepoints (values) of each timestamp
+        (index).
     :return: (*pandas.DataFrame*) -- data frame generation at each plant/timepoint.
     """
     return pd.DataFrame()


### PR DESCRIPTION
### Purpose

Add a skeleton upon which to build the temporal CSV creation features described in #55. This mirrors what was done in #17 to prepare the non-temporal inputs.

### What is the code doing

There is no functional code at the moment, besides unpacking inputs and passing them to the lower-level functions. We are doing `return pd.DataFrame()` at the end of each lower-level function for now so that the main user-facing `profiles_to_switch` function can be tested independently without returning an AttributeError when the skeleton tries to call `to_csv` for lower-level functions that are not yet complete.

### Usage example

An example for how I think this would be used is below (all-caps variable names are for things that the user [or another function] will need to provide)

```python
from powersimdata import Scenario
from switchwrapper.profiles_to_switch import profiles_to_switch
scenario = Scenario(599)
grid = scenario.get_grid()
profiles = {
    "demand": scenario.get_demand(),
    "hydro": scenario.get_hydro(),
    "solar": scenario.get_solar(),
    "wind": scenario.get_wind(),
}
profiles_to_switch(grid, profiles, TIMEPOINTS, TIMESERIES, MAPPING, PATH_TO_OUTPUT_FOLDER)
```

### Time to review

15 minutes.