### PR TITLE
fix: correct column co2_intensity entry in fuels.csv

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -213,7 +213,7 @@ def build_fuels():
     :return: (*pandas.DataFrame*) -- single-row data frame with all params.
     """
     fuels = pd.DataFrame({"fuel": const.fuels})
-    fuels["co2_intensity"] = "."
+    fuels["co2_intensity"] = "0"
     fuels["upstream_co2_intensity"] = "."
     return fuels
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#commit-message)

**Purpose**
Debug grid_to_switch.py function to generate correct fuels.csv file for SWITCH input version 2.0.5.

**What the code is doing**
Adjust original code to populate entries for column "co2_intensity" to "0" instead of ".".

**Testing**
Manual testing, spot-checked against values.

from powersimdata.scenario.scenario import Scenario
from switchwrapper.grid_to_switch import grid_to_switch
scenario = Scenario(599)
grid = scenario.state.get_grid()
grid_to_switch(grid, 'Test')

**Time estimate**
5 minute.

