### PR TITLE
feat: add logic to build_timeseries function

### DIFF
--- a/switchwrapper/profiles_to_switch.py
+++ b/switchwrapper/profiles_to_switch.py
@@ -38,6 +38,9 @@ def profiles_to_switch(
     loads = build_loads(grid.bus, profiles["demand"], timestamp_to_timepoints)
     loads.to_csv(loads_filepath)
 
+    timepoints_filepath = os.path.join(output_folder, "timepoints.csv")
+    timepoints[["timestamp", "timeseries"]].to_csv(timepoints_filepath)
+
     timeseries_filepath = os.path.join(output_folder, "timeseries.csv")
     timeseries = build_timeseries(timepoints, timestamp_to_timepoints)
     timeseries.to_csv(timeseries_filepath, index=False)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose

This addresses the generation of the **timeseries.csv** file as described in #55.

### What the code is doing

- We change the expected type of the `timeseries` input param from a Series (when we though we were only mapping to durations) to a DataFrame (since we need both durations and investment periods, per conversation in #55)
- Within the main `profiles_to_switch` function, we rename the variable we are creating for the **timeseries.csv** file from `timeseries` to `timeseries_df` to eliminate confusion between input and output variables (although this can be changed back, or changed to something else if you think that would be clearer).
- Within `build_timeseries`, we add logic which successfully reproduces example files provided by @YifanLi86. The `ts_num_tps` column is the number of timepoints within each timeseries, and the `ts_scale_to_period` column is the weight for each time series, which happens to sum to 366 in this case because we divide the hour count by the duration of each timeseries multiplied by the number of timepoints in each time series, and 4 * 6 = 24.

### Testing

Tested manually by passing as inputs the information that will need to be provided by the user, and verifying that the outputs match the example output files.
```python
import pandas as pd
from powersimdata import Scenario
from switchwrapper.profiles_to_switch import profiles_to_switch
scenario = Scenario(599)
grid = scenario.get_grid()
profiles = {
    "demand": scenario.get_demand(),
    "hydro": scenario.get_hydro(),
    "solar": scenario.get_solar(),
    "wind": scenario.get_wind(),
}
timepoints = pd.read_csv("timepoints_input.csv", index_col=0)
timeseries = pd.read_csv("timeseries_input.csv", index_col=0)
timestamps_to_timepoints = pd.read_csv("slicing_recovery.csv", index_col=0).squeeze()
profiles_to_switch(grid, profiles, timepoints, timeseries, timestamps_to_timepoints, "profiles_output")
```
Note: the grid and profiles are not actually used here, but we need to include them because the main `profiles_to_switch` does some unpacking before passing information to the lower-level functions.

### Time estimate

15 minutes.