### PR TITLE
Feat: Expand Timepoint Data into Timeseries Data

### DIFF
--- a/switchwrapper/helpers.py
+++ b/switchwrapper/helpers.py
@@ -54,6 +54,7 @@ def load_mapping(filename):
 
 def make_branch_indices(branch_ids, dc=False):
     """Make the indices of existing branch for input to Switch.
+
     :param iterable branch_ids: list of original branch ids.
     :param bool dc: branch_ids are for dclines or not, defaults to False.
     :return: (*list*) -- list of branch indices for input to Switch
@@ -78,7 +79,9 @@ def parse_timepoints(var_dict, variables, mapping):
         are the timestamps contained in the mapping dictionary values.
         The columns of these dataframes are a comma-separated string of the
         parameters embedded in the key of the original input dictionary with
-        the timepoint removed and preserved order otherwise.
+        the timepoint removed and preserved order otherwise. If no variables
+        are found in the input dictionary, the value will be None
+
     """
     # Initialize final dictionary to return
     parsed_data = {}
@@ -90,6 +93,12 @@ def parse_timepoints(var_dict, variables, mapping):
             key + r"\[(?P<params>.*),(?P<timepoint>.*?)\]",
             ["params", "timepoint"],
         )
+
+        # If no such variable was found, set dataframe to None
+        if df.empty:
+            parsed_data[key] = None
+            continue
+
         # Unstack such that the timepoints are the indices
         df = df.set_index(["timepoint", "params"]).unstack()
         # Cast timepoints as ints to match mapping


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Create a function to convert the data contained in the output pickle file produced by `switch` into a pandas dataframe with the correct timestamps to index each data point.

Note that creating the actual `PF`, `PG`, etc. files are not included as part of this functionality. This is intended to be a general-purpose function as an intermediary to reformat the data for further manipulation into the format expected by `PostREISE`.

### What the code is doing
There are 2 functions in the  `helpers.py` file: one to read in the mapping file that will eventually by generated by the input and the other to create the transformed data frames.

There is also a new dictionary mapping in `const.py` to record which parameter is the timepoint for each timeseries variable.

### Where to look
`helpers.py`

### Usage Example/Visuals
```import pickle

from switchwrapper.helpers import parse_timepoints, load_mapping


pickle_file = 'results.pickle'
mapping_file = 'mapping.csv'

with open(pickle_file, 'rb') as f:
    results = pickle.load(f)

data = results.solution._list[0].Variable

mapping = load_mapping(mapping_file)

variables_to_parse = ["DispatchGen", "DispatchTx", "UnservedLoad"]

parsed_data = parse_timepoints(data, variables_to_parse, mapping)
```

### Time estimate
15 min
