### PR TITLE
feat: add main user-facing script which launches all input preparation

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -14,9 +14,6 @@ def grid_to_switch(grid, output_folder):
     :param powersimdata.input.grid.Grid grid: grid instance.
     :param str output_folder: the location to save outputs, created as necessary.
     """
-    # Create the output folder, if it doesn't already exist
-    os.makedirs(output_folder, exist_ok=True)
-
     # First, prompt the user for information not contained in const or the passed grid
     base_year = get_base_year()
     inv_period, period_start, period_end = get_inv_periods()

--- a/switchwrapper/prepare.py
+++ b/switchwrapper/prepare.py
@@ -1,3 +1,5 @@
+import os
+
 from switchwrapper.grid_to_switch import grid_to_switch
 from switchwrapper.profiles_to_switch import _check_timepoints, profiles_to_switch
 
@@ -26,6 +28,9 @@ def prepare_inputs(
     """
     # Validate the input data
     _check_timepoints(timepoints)
+
+    # Create the output folder, if it doesn't already exist
+    os.makedirs(output_folder, exist_ok=True)
 
     grid_to_switch(grid, output_folder)
     profiles_to_switch(

--- a/switchwrapper/profiles_to_switch.py
+++ b/switchwrapper/profiles_to_switch.py
@@ -30,9 +30,6 @@ def profiles_to_switch(
         (index).
     :param str output_folder: the location to save outputs, created as necessary.
     """
-    # Create the output folder, if it doesn't already exist
-    os.makedirs(output_folder, exist_ok=True)
-
     loads_filepath = os.path.join(output_folder, "loads.csv")
     loads = build_loads(grid.bus, profiles["demand"], timestamp_to_timepoints)
     loads.to_csv(loads_filepath)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a main user-facing script which launches all input preparation. Closes #62.

### What the code is doing
The new code does nothing that was not already done by the minimal usage examples for the `grid_to_switch` and `profiles_to_switch` functions. A few things are moved around.

### Testing
Tested manually:
```python
import os

import pandas as pd
from powersimdata import Scenario

from switchwrapper.prepare import prepare_inputs

scenario = Scenario(599)
grid = scenario.get_grid()
profiles = {
    "demand": scenario.get_demand(),
    "hydro": scenario.get_hydro(),
    "solar": scenario.get_solar(),
    "wind": scenario.get_wind(),
}
timepoints = pd.read_csv("timepoints_input_v2.csv", index_col=0)
timestamps_to_timepoints = pd.read_csv("slicing_recovery.csv", index_col=0).squeeze()
prepare_inputs(grid, profiles, timepoints, timestamps_to_timepoints, os.path.join("prepared", "inputs"))
```
(executes successfully)

### Time estimate
5 minutes.
