### PR TITLE
fix: correct bug when setting index name

### DIFF
--- a/switchwrapper/profiles_to_switch.py
+++ b/switchwrapper/profiles_to_switch.py
@@ -117,7 +117,7 @@ def build_timeseries(timepoints, timestamp_to_timepoints):
     timeseries["ts_scale_to_period"] = hours / (
         timeseries["ts_duration_of_tp"] * timeseries["ts_num_tps"]
     )
-    timeseries.index.name == "TIMESERIES"
+    timeseries.index.name = "TIMESERIES"
     timeseries.reset_index(inplace=True)
     return timeseries
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Correct a bug when setting index name for the timeseries data frame.

### What the code is doing
Before: `==` evaluates equality. After: `=` does the assignment that we intended.

### Testing
Manual. Before: Switch complained; after: it did not.

### Time estimate
10 seconds.
