### PR TITLE
feat: add function to write modules.txt file

### DIFF
--- a/switchwrapper/const.py
+++ b/switchwrapper/const.py
@@ -1,3 +1,19 @@
+switch_modules = [
+    "switch_model",
+    "switch_model.timescales",
+    "switch_model.financials",
+    "switch_model.balancing.load_zones",
+    "switch_model.energy_sources.properties",
+    "switch_model.generators.core.build",
+    "switch_model.generators.core.dispatch",
+    "switch_model.generators.core.no_commit",
+    "switch_model.energy_sources.fuel_costs.simple",
+    "switch_model.transmission.local_td",
+    "switch_model.transmission.transport.build",
+    "switch_model.transmission.transport.dispatch",
+    "switch_model.reporting",
+]
+
 financial_parameters = {
     "discount_rate": 0.079,
     "interest_rate": 0.029,

--- a/switchwrapper/prepare.py
+++ b/switchwrapper/prepare.py
@@ -1,5 +1,6 @@
 import os
 
+from switchwrapper import const
 from switchwrapper.grid_to_switch import grid_to_switch
 from switchwrapper.profiles_to_switch import _check_timepoints, profiles_to_switch
 
@@ -36,3 +37,14 @@ def prepare_inputs(
     profiles_to_switch(
         grid, profiles, timepoints, timestamp_to_timepoints, output_folder
     )
+    write_modules(os.path.join(output_folder, ".."))
+
+
+def write_modules(folder):
+    """Create a file containing a list of modules to be imported by Switch.
+
+    :param str folder: the location to save the file.
+    """
+    with open(os.path.join(folder, "modules.txt"), "w") as f:
+        for module in const.switch_modules:
+            f.write(f"{module}\n")


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a function to create the **modules.txt** file which is used to tell Switch which modules to import and use in building the optimization problem. Note: this file is created one level up from the rest of the input files.

### What the code is doing
The list of modules contained in the example data is added to **const.py**, then imported and written as part of the `prepare_inputs` function.

### Testing
Tested manually: the file is created in the expected location, with the expected contents.

### Time estimate
2 minutes.
