### PR TITLE
fix: add 'g' to beginning of predetermined gen build indices

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -358,7 +358,7 @@ def build_gen_build_predetermined(plant):
         },
         inplace=True,
     )
-    original_plant_indices, hypothetical_plant_indices = make_indices(plant.index)
+    original_plant_indices, _ = make_indices(plant.index)
     gen_build_predetermined["GENERATION_PROJECT"] = original_plant_indices
     gen_build_predetermined = gen_build_predetermined[
         ["GENERATION_PROJECT", "build_year", "gen_predetermined_cap"]


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix a bug in how we are generating indices for the **gen_build_predetermined.csv** file. Closes #75.

### What the code is doing
Instead of writing the existing plant indices (`[1, 2, 3, ...]`) we write the transformed ones (`[g1, g2, g3, ...]`) which we get from the `make_indices` function.

### Testing
Tested manually, using a rebased version of the `YifanLi86-patch-1` branch. Before: ValueError as in #75. After: different ValueError (follow-up PR forthcoming).

### Time estimate
2 minutes.
