### PR TITLE
fix: don't write fuel costs for non-fuels (e.g. geothermal)

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -244,7 +244,7 @@ def build_fuel_cost(average_fuel_cost, base_year, inv_period):
     # Clean up columns we don't need
     fuel_cost.drop(columns=["GenFuelCost", "inflation"], inplace=True)
     # Clean up any rows we don't need
-    fuel_cost = fuel_cost.query("fuel_cost > 0")
+    fuel_cost = fuel_cost.query("fuel_cost > 0 and fuel in @const.fuels")
 
     return fuel_cost
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Avoid writing fuel costs for plants with types that do not take fuel. We encounter this problem for plants with "geothermal" type because they have non-zero `GenFuelCost` data in some previously-run Scenarios (e.g. 599), although this appears to be fixed in the current data in the PowerSimData repo, so this should not be an issue for non-legacy Grids.

### What the code is doing
Adding one more filter to the dataframe query before writing fuel costs to a file.

### Testing
Tested manually. Before:
```python
Traceback (most recent call last):
  File "c:\python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Python38\Scripts\switch.exe\__main__.py", line 7, in <module>
  File "c:\python38\lib\site-packages\switch_model\main.py", line 39, in main
    main()
  File "c:\python38\lib\site-packages\switch_model\solve.py", line 122, in main
    instance = model.load_inputs()
  File "c:\python38\lib\site-packages\switch_model\utilities.py", line 164, in load_inputs
    instance = model.create_instance(data)
  File "c:\python38\lib\site-packages\pyomo\core\base\PyomoModel.py", line 733, in create_instance
    instance.load( data,
  File "c:\python38\lib\site-packages\pyomo\core\base\PyomoModel.py", line 790, in load
    self._load_model_data(dp,
  File "c:\python38\lib\site-packages\pyomo\core\base\PyomoModel.py", line 856, in _load_model_data
    self._initialize_component(modeldata, namespaces, component_name, profile_memory)
  File "c:\python38\lib\site-packages\pyomo\core\base\PyomoModel.py", line 910, in _initialize_component
    declaration.construct(data)
  File "c:\python38\lib\site-packages\pyomo\core\base\sets.py", line 1175, in construct
    self.add(val)
  File "c:\python38\lib\site-packages\pyomo\core\base\sets.py", line 822, in add
    self._verify(tmp)
  File "c:\python38\lib\site-packages\pyomo\core\base\sets.py", line 767, in _verify
    raise ValueError("The value="+str(element)+" violates the validation rule of set="+self.name)
ValueError: The value=(2020304, 'Geothermal', 2030) violates the validation rule of set=ZONE_FUEL_PERIODS
```
After:
[a different error, unrelated to the Switch `model.create_instance` call, implying that this step now succeeds successfully]

### Time estimate
2 minutes.
