### PR TITLE
fix: change type of AC lines indices to be str to match DC lines

### DIFF
--- a/switchwrapper/grid_to_switch.py
+++ b/switchwrapper/grid_to_switch.py
@@ -443,6 +443,7 @@ def build_aclines(grid):
             grid.bus.loc[acline["to_bus_id"], "baseKV"],
         )
     )
+    acline["branch_id"] = acline["branch_id"].apply(lambda x: str(x) + "ac")
     return acline.round(2)
 
 
@@ -462,7 +463,7 @@ def build_dclines(grid):
         )
     )
     dcline["trans_efficiency"] = 0.99
-    dcline["dcline_id"] = dcline["dcline_id"].apply(lambda x: str(x) + "dl")
+    dcline["dcline_id"] = dcline["dcline_id"].apply(lambda x: str(x) + "dc")
     dcline.rename(columns={"dcline_id": "branch_id", "Pmax": "rateA"}, inplace=True)
     return dcline.round(2)
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fixes a bug during input preparation which causes Pyomo to fail during a solve (see #80).

### What the code is doing
Previously, AC branch indices were `int` (e.g. `88209`), and DC branch indices were `str` (e.g. `"9dl"`). This fix changes them all to be `str`, so we now have `"88209ac"` and `"9dc"`.

### Testing
Tested manually. Previously, we would see the TypeError in #80, now we don't.

### Time estimate
2 minutes.
