### PR TITLE
refactor: rename folder parameter of prepare_inputs function

### DIFF
--- a/switchwrapper/prepare.py
+++ b/switchwrapper/prepare.py
@@ -12,7 +12,7 @@ def prepare_inputs(
     profiles,
     timepoints,
     timestamp_to_timepoints,
-    output_folder="inputs",
+    switch_files_root=None,
 ):
     """Prepare all grid and profile data into a format expected by Switch.
 
@@ -27,20 +27,22 @@ def prepare_inputs(
         another table in a relational database.
     :param pandas.Series timestamp_to_timepoints: timepoints (values) of each timestamp
         (index).
-    :param str output_folder: the location to save outputs, created as necessary.
+    :param str switch_files_root: the location to save all Switch files.
     """
     # Validate the input data
     _check_timepoints(timepoints)
 
-    # Create the output folder, if it doesn't already exist
-    os.makedirs(output_folder, exist_ok=True)
+    # Create the 'inputs' folder, if it doesn't already exist
+    switch_files_root = os.getgwd() if switch_files_root is None else switch_files_root
+    inputs_folder = os.path.join(switch_files_root, "inputs")
+    os.makedirs(inputs_folder, exist_ok=True)
 
-    grid_to_switch(grid, output_folder)
+    grid_to_switch(grid, inputs_folder)
     profiles_to_switch(
-        grid, profiles, timepoints, timestamp_to_timepoints, output_folder
+        grid, profiles, timepoints, timestamp_to_timepoints, inputs_folder
     )
-    write_version_file(output_folder)
-    write_modules(os.path.join(output_folder, ".."))
+    write_version_file(inputs_folder)
+    write_modules(switch_files_root)
 
 
 def write_modules(folder):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Change `prepare_inputs` folder parameter to something more intuitive. Instead of specifying the `inputs` subfolder as the `output_folder` parameter, specify the root folder (containing the modules list, inputs subfolder, and outputs subfolder) as `switch_files_root`.

### Time estimate
5 minutes.
