### PR TITLE
feat: save grid in pickle file for use in output processing

### DIFF
--- a/switchwrapper/prepare.py
+++ b/switchwrapper/prepare.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import switch_model
 
@@ -43,6 +44,10 @@ def prepare_inputs(
     )
     write_version_file(inputs_folder)
     write_modules(switch_files_root)
+
+    # Save a copy of the grid object for use in output processing
+    with open(os.path.join(inputs_folder, "grid.pkl"), "wb") as f:
+        pickle.dump(grid, f)
 
 
 def write_modules(folder):


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Save the Grid object used to create the Switch inputs.

### What the code is doing
Using `pickle`.

### Testing
Tested manually: the Grid obtained from reading the pickle file evaluates as equal to the one passed as input:
```pickle
>>> import os
>>> import pandas as pd
>>> from powersimdata import Scenario
>>> from switchwrapper.prepare import prepare_inputs
>>>
>>> scenario = Scenario(599)
>>> grid = scenario.get_grid()
>>> profiles = {
...     "demand": scenario.get_demand(),
...     "hydro": scenario.get_hydro(),
...     "solar": scenario.get_solar(),
...     "wind": scenario.get_wind(),
... }
>>> timepoints = pd.read_csv("timepoints_input_v2.csv", index_col=0)
>>> timestamps_to_timepoints = pd.read_csv("slicing_recovery.csv", index_col=0).squeeze()
>>> prepare_inputs(grid, profiles, timepoints, timestamps_to_timepoints, "prepared")
Please enter base study year (normally PowerSimData scenario year): 2030
Please enter the number of investment stages: 1
Single stage expansion identified.
Please enter investment period year, separate by space: 2030
Please enter start year for each period, separate by space: 2030
Please enter end year for each period, separate by space: 2030
>>> import pickle
>>> with open(os.path.join("prepared", "inputs", "grid.pkl"), "rb") as f:
...     grid2 = pickle.load(f)
...
>>> grid == grid2
True
```

### Time estimate
2 minutes.
