### PR TITLE
chore: add files to enable pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+name = SwitchWrapper
+version = 0.1.0
+install_requires = 
+    haversine~=2.3
+    pandas~=1.2
+    -e git+https://github.com/Breakthrough-Energy/PowerSimData#egg=PowerSimData
+    switch-model==2.0.6
+tests_require = 
+    pytest

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add files to enable a successful `pip install`. Closes #70.

### What the code is doing
- **pyproject.toml** provides the minimal information to specify the build backend.
- **setup.py** provides the minimal code required to still `pip install -e` (if we never want to do an editable install, this file is not strictly needed).
- **setup.cfg** provides the specification of requirements as well as other package metadata.

### Testing
Tested manually, works properly.

### Time estimate
5 minutes to understand what's here, potentially much longer if you want to go down the rabbit hole of why we need all of these separate files. Eventually, it seems like `setuptools` will move towards having all information in the **pyproject.toml** (like poetry), but it's not there yet.
